### PR TITLE
fixed parsing of floats (issue #1)

### DIFF
--- a/RoundsButIFailAtMath/RoundButIFailAtMath.cs
+++ b/RoundsButIFailAtMath/RoundButIFailAtMath.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Globalization;
 using BepInEx;
 using BepInEx.Configuration;
 using Photon.Pun;
@@ -139,7 +140,7 @@ namespace RoundsButIFailAtMath
 
                     // Randomise multiplier
                     float MULTIPLIER = (float)(rng.NextDouble() * (rangeMax - rangeMin) + rangeMin);
-                    float amount = float.Parse(label) * MULTIPLIER; // Calculate new modifier
+                    float amount = float.Parse(label, CultureInfo.InvariantCulture) * MULTIPLIER; // Calculate new modifier. use CultureInfo.InvariantCulture to make sure a period is used as the decimal seperator
 
                     // Update recognised card stats
                     switch (stat.stat)


### PR DESCRIPTION
fixed issue #1 where the mod would not work on some machines as they had a culture veriable that made it so when parsing the incomming label to float it expected a comma to be the decimal seperator, but it would get a period instead. This would thow an error stoping the mod from modifying the rest of the cards